### PR TITLE
Register org.kohsuke.github.JsonRateLimit for reflection

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/githubapi/deployment/GitHubApiDotNames.java
+++ b/deployment/src/main/java/io/quarkiverse/githubapi/deployment/GitHubApiDotNames.java
@@ -175,6 +175,7 @@ final class GitHubApiDotNames {
     private static final DotName GITHUB_REQUEST = DotName.createSimple("org.kohsuke.github.GitHubRequest");
     private static final DotName GITHUB_REQUEST_ENTRY = DotName.createSimple("org.kohsuke.github.GitHubRequest$Entry");
     private static final DotName GITHUB_RESPONSE = DotName.createSimple("org.kohsuke.github.GitHubResponse");
+    private static final DotName JSON_RATE_LIMIT = DotName.createSimple("org.kohsuke.github.JsonRateLimit");
 
     static final List<DotName> GH_SIMPLE_OBJECTS = Arrays.asList(GH_APP_INSTALLATION_GH_APP_INSTALLATION_REPOSITORY_RESULT,
             GH_APP_INSTALLATION_TOKEN, GH_APP_AUTHORIZATION_APP, GH_BLOB,
@@ -199,7 +200,7 @@ final class GitHubApiDotNames {
             GH_REPOSITORY_STATISTICS, GH_REPOSITORY_STATISTICS_CONTRIBUTOR_STATS_WEEK, GH_REPOSITORY_STATISTICS_CODE_FREQUENCY,
             GH_REPOSITORY_STATISTICS_PUNCH_CARD_ITEM, GH_STARGAZER, GH_SUBSCRIPTION, GH_TAG, GH_TAG_OBJECT, GH_THREAD_SUBJECT,
             GH_TREE, GH_TREE_ENTRY,
-            GH_VERIFICATION, GITHUB_REQUEST, GITHUB_REQUEST_ENTRY, GITHUB_RESPONSE);
+            GH_VERIFICATION, GITHUB_REQUEST, GITHUB_REQUEST_ENTRY, GITHUB_RESPONSE, JSON_RATE_LIMIT);
 
     private GitHubApiDotNames() {
     }


### PR DESCRIPTION
Register org.kohsuke.github.JsonRateLimit for reflection

Without that I receive
```
Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `org.kohsuke.github.JsonRateLimit` (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
 at [Source: (String)"{"resources":{"core":{"limit":5000,"used":61,"remaining":4939,"reset":1613767242},"search":{"limit":30,"used":0,"remaining":30,"reset":1613765157},"graphql":{"limit":5000,"used":0,"remaining":5000,"reset":1613768697},"integration_manifest":{"limit":5000,"used":0,"remaining":5000,"reset":1613768697},"source_import":{"limit":100,"used":0,"remaining":100,"reset":1613765157},"code_scanning_upload":{"limit":500,"used":0,"remaining":500,"reset":1613768697}},"rate":{"limit":5000,"used":61,"remaining":4"[truncated 24 chars]; line: 1, column: 2]
	at com.fasterxml.jackson.databind.DeserializationContext.reportBadDefinition(DeserializationContext.java:1615)
	at com.fasterxml.jackson.databind.DatabindContext.reportBadDefinition(DatabindContext.java:400)
	at com.fasterxml.jackson.databind.DeserializationContext.handleMissingInstantiator(DeserializationContext.java:1077)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1332)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:331)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:164)
	at com.fasterxml.jackson.databind.ObjectReader._bindAndClose(ObjectReader.java:2079)
	at com.fasterxml.jackson.databind.ObjectReader.readValue(ObjectReader.java:1518)
	at org.kohsuke.github.GitHubResponse.parseBody(GitHubResponse.java:96)
	at org.kohsuke.github.GitHubClient.lambda$getRateLimit$1(GitHubClient.java:232)
	at org.kohsuke.github.GitHubClient.createResponse(GitHubClient.java:455)
	at org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:406)
```

Using https://github.com/rsvoboda/gh-exporter/tree/quarkus-github-api / https://github.com/rsvoboda/gh-exporter/blob/quarkus-github-api/src/main/java/io/quarkus/qe/metrics/GHRepositoryBaseMetrics.java#L108
