### PR TITLE
Release 1.125.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Quarkus GitHub API
 release:
-  current-version: 1.0.1
-  next-version: 1.0.2-SNAPSHOT
+  current-version: 1.125.0
+  next-version: 1.126.0-SNAPSHOT
 


### PR DESCRIPTION
Let's align on the Hub4j GitHub API versions given it's only a wrapper on top of it.