### PR TITLE
Do not make OkHttp a forced dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
 
         <github-api.version>1.301</github-api.version>
-        <okhttp.version>4.9.2</okhttp.version>
     </properties>
 
     <modules>
@@ -48,11 +47,6 @@
                 <groupId>org.kohsuke</groupId>
                 <artifactId>github-api</artifactId>
                 <version>${github-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp</artifactId>
-                <version>${okhttp.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -21,10 +21,6 @@
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Now that GitHub API has a properly working JDK 11 HTTP client
implementation, we can make OkHttp fully optional.