### PR TITLE
Upgrade to Quarkus 3.8.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <quarkus.version>3.6.4</quarkus.version>
+        <quarkus.version>3.8.5</quarkus.version>
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <resource-plugin.version>3.3.1</resource-plugin.version>
         <surefire-plugin.version>3.3.0</surefire-plugin.version>


### PR DESCRIPTION
Let's stick with the LTS for now as it's a low level library.